### PR TITLE
Upgrade Radar from 1.1.x to 1.2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,5 @@ android {
 }
 
 dependencies {
-    compile 'com.onradar:sdk:[1.1,1.2)'
+    compile 'com.onradar:sdk:[1.2,1.3)'
 }


### PR DESCRIPTION
1.2.x adds Android O support and requires no code changes to upgrade. See https://blog.onradar.com/radar-sdk-v1-2-with-ios-11-and-android-o-support-now-available-ee5c12b9f25.