### PR TITLE
Upgrade Radar to 1.2.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile ('com.onradar:sdk:1.2.16') {
+    compile ('com.onradar:sdk:1.2.27') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     compile 'com.android.support:support-v4:[26.0,27.0)'


### PR DESCRIPTION
Alternatively, can we use `compile 'com.onradar:sdk:[1.2,1.3)'` per https://github.com/mparticle-integrations/mparticle-android-integration-radar/pull/3/files? Thanks!