### PR TITLE
Proactively grab customer ID during initialization, bump Radar to 1.3.0 to allow anonymous tracking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile ('com.onradar:sdk:[1.2,1.3)') {
+    compile ('com.onradar:sdk:[1.3,1.4)') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     compile 'com.android.support:support-v4:[26.0,27.0)'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile ('com.onradar:sdk:1.2.16') {
+    compile ('com.onradar:sdk:[1.2,1.3)') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     compile 'com.android.support:support-v4:[26.0,27.0)'

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -40,8 +40,12 @@ public class RadarKit extends KitIntegration implements KitIntegration.ActivityL
         mRunAutomatically = settings.containsKey(KEY_RUN_AUTOMATICALLY) && Boolean.parseBoolean(settings.get(KEY_RUN_AUTOMATICALLY));
 
         Radar.initialize(context, publishableKey);
-        
-        // TODO proactively get customer ID and call Radar.setUserId(customerId)?
+
+        Map<MParticle.IdentityType, String> identities = getUserIdentities();
+        String customerId = identities.get(MParticle.IdentityType.CustomerId);
+        if (customerId != null) {
+            Radar.setUserId(customerId);
+        }
 
         if (mRunAutomatically) {
             this.tryTrackOnce();
@@ -128,7 +132,12 @@ public class RadarKit extends KitIntegration implements KitIntegration.ActivityL
     public void setUserIdentity(MParticle.IdentityType identityType, String id) {
         if (identityType.equals(MParticle.IdentityType.Alias)) {
             Radar.reidentifyUser(id);
-            // TODO get new customer ID and call Radar.setUserId(customerId)?
+            
+            Map<MParticle.IdentityType, String> identities = getUserIdentities();
+            String customerId = identities.get(MParticle.IdentityType.CustomerId);
+            if (customerId != null) {
+                Radar.setUserId(customerId);
+            }
 
             if (mRunAutomatically) {
                 this.tryTrackOnce();

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -130,20 +130,7 @@ public class RadarKit extends KitIntegration implements KitIntegration.ActivityL
 
     @Override
     public void setUserIdentity(MParticle.IdentityType identityType, String id) {
-        if (identityType.equals(MParticle.IdentityType.Alias)) {
-            Radar.reidentifyUser(id);
-            
-            Map<MParticle.IdentityType, String> identities = getUserIdentities();
-            String customerId = identities.get(MParticle.IdentityType.CustomerId);
-            if (customerId != null) {
-                Radar.setUserId(customerId);
-            }
-
-            if (mRunAutomatically) {
-                this.tryTrackOnce();
-                this.tryStartTracking();
-            }
-        } else if (identityType.equals(MParticle.IdentityType.CustomerId)) {
+        if (identityType.equals(MParticle.IdentityType.CustomerId)) {
             Radar.setUserId(id);
 
             if (mRunAutomatically) {

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -40,8 +40,11 @@ public class RadarKit extends KitIntegration implements KitIntegration.ActivityL
         mRunAutomatically = settings.containsKey(KEY_RUN_AUTOMATICALLY) && Boolean.parseBoolean(settings.get(KEY_RUN_AUTOMATICALLY));
 
         Radar.initialize(context, publishableKey);
+        
+        // TODO proactively get customer ID and call Radar.setUserId(customerId)?
 
         if (mRunAutomatically) {
+            this.tryTrackOnce();
             this.tryStartTracking();
         }
 
@@ -123,10 +126,19 @@ public class RadarKit extends KitIntegration implements KitIntegration.ActivityL
 
     @Override
     public void setUserIdentity(MParticle.IdentityType identityType, String id) {
-        if (identityType.equals(MParticle.IdentityType.CustomerId)) {
+        if (identityType.equals(MParticle.IdentityType.Alias)) {
+            Radar.reidentifyUser(id);
+            // TODO get new customer ID and call Radar.setUserId(customerId)?
+
+            if (mRunAutomatically) {
+                this.tryTrackOnce();
+                this.tryStartTracking();
+            }
+        } else if (identityType.equals(MParticle.IdentityType.CustomerId)) {
             Radar.setUserId(id);
 
             if (mRunAutomatically) {
+                this.tryTrackOnce();
                 this.tryStartTracking();
             }
         }


### PR DESCRIPTION
TODO: Can we proactively get customer ID and call `Radar.setUserId(customerId)` on initialization and on alias changes?