### PR TITLE
Update to Radar SDK 2.1.8. Use new mParticle Identity APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-    api ('io.radar:sdk:[2.1,2.2)') {
+    api ('io.radar:sdk:2.1.8') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     api 'com.android.support:appcompat-v7:28.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     api ('io.radar:sdk:[2.1,2.2)') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
-    api 'com.android.support:appcompat-v7:27.1.1'
+    api 'com.android.support:appcompat-v7:28.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ android {
 }
 
 dependencies {
-    compile ('io.radar:sdk:[2.0.15,2.1)') {
+    api ('io.radar:sdk:[2.1,2.2)') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
-    compile 'com.android.support:appcompat-v7:27.1.1'
+    api 'com.android.support:appcompat-v7:27.1.1'
 }

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -58,6 +58,8 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
         if (mRunAutomatically) {
             this.tryTrackOnce();
             this.tryStartTracking();
+        } else {
+            Radar.stopTracking();
         }
 
         List<ReportingMessage> messageList = new LinkedList<>();
@@ -74,6 +76,8 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
     public void onApplicationForeground() {
         if (mRunAutomatically) {
             this.tryTrackOnce();
+        } else {
+            Radar.stopTracking();
         }
     }
 

--- a/src/test/java/com/mparticle/kits/RadarKitTests.java
+++ b/src/test/java/com/mparticle/kits/RadarKitTests.java
@@ -3,12 +3,16 @@ package com.mparticle.kits;
 
 import android.content.Context;
 
+import com.mparticle.MParticle;
+import com.mparticle.identity.MParticleUser;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -54,5 +58,20 @@ public class RadarKitTests {
             }
         }
         fail(className + " not found as a known integration.");
+    }
+
+    @Test
+    public void testSetUser() throws Exception {
+        RadarKit kit = new RadarKit();
+        kit.mRunAutomatically = false;
+        assertFalse(kit.setUserAndTrack(null, "foo"));
+        MParticleUser user = Mockito.mock(MParticleUser.class);
+        Map<MParticle.IdentityType, String> identities = new HashMap<>();
+        identities.put(MParticle.IdentityType.CustomerId, "foo");
+        Mockito.when(user.getUserIdentities()).thenReturn(identities);
+        assertTrue(kit.setUserAndTrack(user, "bar"));
+        assertTrue(kit.setUserAndTrack(user, null));
+        identities.clear();
+        assertTrue(kit.setUserAndTrack(user, "foo"));
     }
 }


### PR DESCRIPTION
Updating to use new `2.1.8` SDK version. Plus moving from deprecated mParticle APIs to new Identity APIs. 

@samdozor - I couldn't find super detailed documentation so want to double check I mapped the old APIs to the new methods correctly:
`AttributeListener.setUserIdentity` -> `IdentityListener.onIdentifyCompleted`
`AttributeListener.removeUserIdentity` -> `IdentityListener.onModifyCompleted` (and we check for removal of `CustomerId`) 
`AttributeListener.logout` -> `IdentityListener.onLogoutCompleted`

All we care about is changes to `CustomerID` so let me know if there's a better use of these APIs that I may be missing.