### PR TITLE
Remove extra trackOnce

### DIFF
--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -57,8 +57,7 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
             Radar.setUserId(customerId);
         }
         if (mRunAutomatically) {
-            this.tryTrackOnce();
-            this.tryStartTracking();
+            tryStartTracking();
         } else {
             Radar.stopTracking();
         }


### PR DESCRIPTION
Instead of calling `trackOnce` on kit create and app foreground, instead just track on app foreground. 