### PR TITLE
Move to mParticle id based identity resolution

### DIFF
--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -3,6 +3,8 @@ package com.mparticle.kits;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.util.Log;
+
 import androidx.core.app.ActivityCompat;
 
 import com.mparticle.MParticle;
@@ -44,9 +46,9 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
 
     @Override
     protected List<ReportingMessage> onKitCreate(Map<String, String> settings, Context context) {
+        Log.d("TEST","on kit create");
         String publishableKey = settings.get(KEY_PUBLISHABLE_KEY);
         mRunAutomatically = settings.containsKey(KEY_RUN_AUTOMATICALLY) && Boolean.parseBoolean(settings.get(KEY_RUN_AUTOMATICALLY));
-
         Radar.initialize(context, publishableKey);
         Radar.setAdIdEnabled(true);
         MParticleUser user = getCurrentUser();
@@ -58,7 +60,8 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
             }
             JSONObject radarMetadata = new JSONObject();
             try {
-                radarMetadata.put("mParticleId", user.getId());
+                radarMetadata.put("mParticleId",
+                        Long.toString(user.getId()));
             } catch (JSONException e) {
                 e.printStackTrace();
             }
@@ -102,15 +105,15 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
             return false;
         }
         String newCustomerId = user.getUserIdentities().get(MParticle.IdentityType.CustomerId);
-        long newMpId = user.getId();
-        long currentMpId = 0;
+        String newMpId = Long.toString(user.getId());
+        String currentMpId = null;
         try {
-            currentMpId = currentMetadata.getLong("mParticleId");
+            currentMpId = currentMetadata.getString("mParticleId");
         } catch (JSONException e) {
             e.printStackTrace();
         }
         boolean updatedCustomerId = newCustomerId == null ? currentRadarId != null : !newCustomerId.equals(currentRadarId);
-        boolean updatedMpId = newMpId == currentMpId;
+        boolean updatedMpId = newMpId == null ? currentMpId != null : !newMpId.equals(currentMpId);
         if ((updatedCustomerId) && !unitTesting) {
             Radar.setUserId(newCustomerId);
         }

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -46,7 +46,6 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
 
     @Override
     protected List<ReportingMessage> onKitCreate(Map<String, String> settings, Context context) {
-        Log.d("TEST","on kit create");
         String publishableKey = settings.get(KEY_PUBLISHABLE_KEY);
         mRunAutomatically = settings.containsKey(KEY_RUN_AUTOMATICALLY) && Boolean.parseBoolean(settings.get(KEY_RUN_AUTOMATICALLY));
         Radar.initialize(context, publishableKey);

--- a/src/test/java/com/mparticle/kits/RadarKitTests.java
+++ b/src/test/java/com/mparticle/kits/RadarKitTests.java
@@ -64,7 +64,7 @@ public class RadarKitTests {
     public void testSetUser() throws Exception {
         RadarKit kit = new RadarKit();
         kit.mRunAutomatically = false;
-        JSONObject o = new JSONObject()
+        JSONObject o = new JSONObject();
         assertFalse(kit.setUserAndTrack(null, "foo", o));
         MParticleUser user = Mockito.mock(MParticleUser.class);
         Map<MParticle.IdentityType, String> identities = new HashMap<>();

--- a/src/test/java/com/mparticle/kits/RadarKitTests.java
+++ b/src/test/java/com/mparticle/kits/RadarKitTests.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class RadarKitTests {
 
     private KitIntegration getKit() {

--- a/src/test/java/com/mparticle/kits/RadarKitTests.java
+++ b/src/test/java/com/mparticle/kits/RadarKitTests.java
@@ -64,15 +64,23 @@ public class RadarKitTests {
     public void testSetUser() throws Exception {
         RadarKit kit = new RadarKit();
         kit.mRunAutomatically = false;
-        assertFalse(kit.setUserAndTrack(null, "foo"));
+        JSONObject o = new JSONObject()
+        assertFalse(kit.setUserAndTrack(null, "foo", o));
         MParticleUser user = Mockito.mock(MParticleUser.class);
         Map<MParticle.IdentityType, String> identities = new HashMap<>();
         identities.put(MParticle.IdentityType.CustomerId, "foo");
+        JSONObject radarMetadata = new JSONObject();
+        try {
+            radarMetadata.put("mParticleId",
+                    Long.toString(user.getId()));
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
         Mockito.when(user.getUserIdentities()).thenReturn(identities);
-        assertFalse(kit.setUserAndTrack(user, "foo", true));
-        assertTrue(kit.setUserAndTrack(user, "bar", true));
-        assertTrue(kit.setUserAndTrack(user, null, true));
+        assertFalse(kit.setUserAndTrack(user, "foo", o, true));
+        assertTrue(kit.setUserAndTrack(user, "bar", radarMetadata, true));
+        assertTrue(kit.setUserAndTrack(user, null, o, true));
         identities.clear();
-        assertTrue(kit.setUserAndTrack(user, "foo", true));
+        assertTrue(kit.setUserAndTrack(user, "foo", radarMetadata, true));
     }
 }


### PR DESCRIPTION
This change allows for matching on the `mpid` instead of assuming the customer Id will be present for non anonymized users.  Below is how I am seeing the mP Radar Kit>Radar>mP servers interactions to ensure identity resolution irrespective of a mutual customers identity hierarchy.

1. mParticle SDK initializes the Radar kit
2. The Radar kit is created and collects the mParticle id in Radar as user metadata
3. A Radar event occurs (this is our server determining an event occurred). We look up the users metadata for the mParticle id and pass this as the "mpid" attribute in server to server events (https://docs.mparticle.com/developers/server/http/#v2events). This needs to be a string when sent to our servers.
4. The mParticle SDK determines there is an identity change and the `mpid` changes (i.e mP logout)
5. The Radar kit is listening for these mp id changes and updates the user metadata in our system to reflect any change to a new mp id
6. New radar events occur and are now passed with the updated mp id in Radar server to mP server api calls.

Once this looks good, I will make the necessary changes on the iOS kit.

