### PR TITLE
kit identity resolution on mparticle id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 gradle/
 gradlew
 gradlew.bat
+gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.mparticle:android-kit-plugin:' + project.version
-        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.mparticle:android-kit-plugin:' + project.version
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 
@@ -42,4 +43,5 @@ android {
 
 dependencies {
     api 'io.radar:sdk:3.0.6'
+    testImplementation 'org.json:json:20140107'
 }

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -16,6 +16,9 @@ import io.radar.sdk.Radar;
 import io.radar.sdk.Radar.RadarTrackCallback;
 import io.radar.sdk.RadarTrackingOptions;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class RadarKit extends KitIntegration implements KitIntegration.ApplicationStateListener, KitIntegration.IdentityListener {
 
     private static final String KEY_PUBLISHABLE_KEY = "publishableKey";
@@ -53,6 +56,14 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
             if (customerId != null) {
                 Radar.setUserId(customerId);
             }
+            JSONObject radarMetadata = new JSONObject();
+            try {
+                radarMetadata.put("mParticleId",
+                        Long.toString(user.getId()));
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+            Radar.setMetadata(radarMetadata);
         }
         if (mRunAutomatically) {
             tryStartTracking();
@@ -83,48 +94,71 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
     public void onApplicationBackground() {
     }
 
-    boolean setUserAndTrack(MParticleUser user, String currentRadarId) {
-        return setUserAndTrack(user, currentRadarId, false);
+    boolean setUserAndTrack(MParticleUser user, String currentRadarId, JSONObject currentMetadata) {
+        return setUserAndTrack(user, currentRadarId, currentMetadata, false);
     }
 
-    boolean setUserAndTrack(MParticleUser user, String currentRadarId, boolean unitTesting) {
+    boolean setUserAndTrack(MParticleUser user, String currentRadarId, JSONObject currentMetadata, boolean unitTesting) {
         if (user == null) {
             return false;
         }
-        String newId = user.getUserIdentities().get(MParticle.IdentityType.CustomerId);
-        boolean updatedId = newId == null ? currentRadarId != null : !newId.equals(currentRadarId);
-        if (updatedId && !unitTesting) {
-            Radar.setUserId(newId);
+        String newCustomerId = user.getUserIdentities().get(MParticle.IdentityType.CustomerId);
+        String newMpId = null;
+        if (Long.toString(user.getId()) != null) {
+            newMpId = Long.toString(user.getId());
+        }
+        String currentMpId = null;
+        if (currentMetadata.has("mParticleId")) {
+            try {
+                currentMpId = currentMetadata.getString("mParticleId");
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+        boolean updatedCustomerId = newCustomerId == null ? currentRadarId != null : !newCustomerId.equals(currentRadarId);
+        boolean updatedMpId = newMpId == null ? currentMpId != null : !newMpId.equals(currentMpId);
+        if ((updatedCustomerId) && !unitTesting) {
+            Radar.setUserId(newCustomerId);
+        }
+        if ((updatedMpId) && !unitTesting) {
+            try {
+                currentMetadata.put("mParticleId", newMpId);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+            Radar.setMetadata(currentMetadata);
+        }
+        if ((updatedCustomerId || updatedMpId) && !unitTesting) {
             if (mRunAutomatically) {
                 tryTrackOnce();
                 tryStartTracking();
             }
         }
-        return updatedId;
+        return updatedCustomerId || updatedMpId;
     }
 
     @Override
     public void onIdentifyCompleted(MParticleUser mParticleUser,
         FilteredIdentityApiRequest filteredIdentityApiRequest) {
-        setUserAndTrack(mParticleUser, Radar.getUserId());
+        setUserAndTrack(mParticleUser, Radar.getUserId(), Radar.getMetadata());
     }
 
     @Override
     public void onLoginCompleted(MParticleUser mParticleUser,
         FilteredIdentityApiRequest filteredIdentityApiRequest) {
-        setUserAndTrack(mParticleUser, Radar.getUserId());
+        setUserAndTrack(mParticleUser, Radar.getUserId(), Radar.getMetadata());
     }
 
     @Override
     public void onLogoutCompleted(MParticleUser mParticleUser,
         FilteredIdentityApiRequest filteredIdentityApiRequest) {
-        setUserAndTrack(mParticleUser, Radar.getUserId());
+        setUserAndTrack(mParticleUser, Radar.getUserId(), Radar.getMetadata());
     }
 
     @Override
     public void onModifyCompleted(MParticleUser mParticleUser,
         FilteredIdentityApiRequest filteredIdentityApiRequest) {
-        setUserAndTrack(mParticleUser, Radar.getUserId());
+        setUserAndTrack(mParticleUser, Radar.getUserId(), Radar.getMetadata());
     }
 
     @Override

--- a/src/main/java/com/mparticle/kits/RadarKit.java
+++ b/src/main/java/com/mparticle/kits/RadarKit.java
@@ -104,7 +104,7 @@ public class RadarKit extends KitIntegration implements KitIntegration.Applicati
         }
         String newCustomerId = user.getUserIdentities().get(MParticle.IdentityType.CustomerId);
         String newMpId = null;
-        if (Long.toString(user.getId()) != null) {
+        if (Long.toString(user.getId()) != null && Long.valueOf(user.getId()).intValue() != 0) {
             newMpId = Long.toString(user.getId());
         }
         String currentMpId = null;

--- a/src/test/java/com/mparticle/kits/RadarKitTests.java
+++ b/src/test/java/com/mparticle/kits/RadarKitTests.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class RadarKitTests {
 
     private KitIntegration getKit() {
@@ -64,15 +67,18 @@ public class RadarKitTests {
     public void testSetUser() throws Exception {
         RadarKit kit = new RadarKit();
         kit.mRunAutomatically = false;
-        assertFalse(kit.setUserAndTrack(null, "foo"));
+        JSONObject o = new JSONObject();
+        o.put("mParticleId","5");
+        assertFalse(kit.setUserAndTrack(null, "foo", o));
         MParticleUser user = Mockito.mock(MParticleUser.class);
         Map<MParticle.IdentityType, String> identities = new HashMap<>();
         identities.put(MParticle.IdentityType.CustomerId, "foo");
         Mockito.when(user.getUserIdentities()).thenReturn(identities);
-        assertFalse(kit.setUserAndTrack(user, "foo", true));
-        assertTrue(kit.setUserAndTrack(user, "bar", true));
-        assertTrue(kit.setUserAndTrack(user, null, true));
+        Mockito.when(user.getId()).thenReturn(5L);
+        assertFalse(kit.setUserAndTrack(user, "foo", o, true));
+        assertTrue(kit.setUserAndTrack(user, "bar", o, true));
+        assertTrue(kit.setUserAndTrack(user, null, o, true));
         identities.clear();
-        assertTrue(kit.setUserAndTrack(user, "foo", true));
+        assertTrue(kit.setUserAndTrack(user, "foo", o, true));
     }
 }


### PR DESCRIPTION
This change allows for matching on the mpid instead of assuming the customer Id will be present for non anonymized users. Below is how I am seeing the mP Radar Kit>Radar>mP servers interactions to ensure identity resolution irrespective of a mutual customers identity hierarchy.

1. mParticle SDK initializes the Radar kit
2. The Radar kit is created and collects the mParticle id in Radar as user metadata
3. A Radar event occurs (this is our server determining an event occurred). We look up the users metadata for the mParticle id and pass this as the "mpid" attribute in server to server events (https://docs.mparticle.com/developers/server/http/#v2events). This needs to be a string when sent to and from our servers.
4. The mParticle SDK determines there is an identity change and the mpid changes (i.e mP logout)
5. The Radar kit is listening for these mp id changes and updates the user metadata in our system to reflect any change to a new mp id
6. New radar events occur and are now passed with the updated mp id in Radar server to mP server api calls.
Once this looks good, I will make the necessary changes on the iOS kit.