### PR TITLE
chore: bump to 3.8.13,  remove setAdIdEnabled (deprecated), 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    api 'io.radar:sdk:3.5.11'
+    api 'io.radar:sdk:3.8.13'
     testImplementation 'org.json:json:20220924'
 }
 

--- a/src/main/kotlin/com/mparticle/kits/RadarKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/RadarKit.kt
@@ -12,7 +12,6 @@ import io.radar.sdk.Radar
 import io.radar.sdk.Radar.getMetadata
 import io.radar.sdk.Radar.getUserId
 import io.radar.sdk.Radar.initialize
-import io.radar.sdk.Radar.setAdIdEnabled
 import io.radar.sdk.Radar.setMetadata
 import io.radar.sdk.Radar.setUserId
 import io.radar.sdk.Radar.startTracking
@@ -54,7 +53,6 @@ class RadarKit : KitIntegration(), ApplicationStateListener, IdentityListener {
         mRunAutomatically =
             settings.containsKey(KEY_RUN_AUTOMATICALLY) && settings[KEY_RUN_AUTOMATICALLY].toBoolean()
         initialize(context, publishableKey, null)
-        setAdIdEnabled(true)
         val user = currentUser
         if (user != null) {
             val identities = user.userIdentities


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Bumps Radar SDK version to `3.8.13`
- Removes deprecated `setAdIdEnabled` function

 ## Testing Plan
 - [ ] not tested locally — is there an example app you use to test this?
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
